### PR TITLE
Fix timezone bug in DateUtils

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/utils/DateUtils.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/DateUtils.java
@@ -59,6 +59,7 @@ public class DateUtils {
 
   public static String toISODateString(Date date) {
     SimpleDateFormat isoDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    isoDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
     return isoDateFormat.format(date);
   }
 


### PR DESCRIPTION
## Summary
- fix missing timezone setting in `DateUtils.toISODateString`

## Testing
- `mvn -q -pl xchange-core -am test` *(fails: Plugin resolution, network unreachable)*
- `mvn -q -DskipTests -pl xchange-core -am install` *(fails: Plugin resolution, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6886db2417688331b2f25fb17c937f93