### PR TITLE
Clean up TODO comments, improve exchange integrations, add quant example

### DIFF
--- a/xchange-bitz/src/main/java/org/knowm/xchange/bitz/service/BitZDigest.java
+++ b/xchange-bitz/src/main/java/org/knowm/xchange/bitz/service/BitZDigest.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitz.service;
 
 import jakarta.ws.rs.FormParam;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -16,25 +17,19 @@ public class BitZDigest implements ParamsDigest {
     this.md5 = MessageDigest.getInstance("MD5");
   }
 
-  // TODO: Handle Exception
   public static BitZDigest createInstance() {
     try {
       return new BitZDigest();
     } catch (NoSuchAlgorithmException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
+      throw new IllegalStateException("Unable to load MD5 digest", e);
     }
-
-    return null;
   }
 
-  // TODO: Fix Current Signing - Rejected By Exchange
   @Override
   public String digestParams(RestInvocation restInvocation) {
     // Get Parameters
     Map<String, String> params = restInvocation.getParamsMap().get(FormParam.class).asHttpHeaders();
 
-    // TODO: Find More Elegant Solution To Remove Sign
     // Order By Key Alphabetically, Concancecate Values
     byte[] unsigned =
         params.entrySet().stream()
@@ -42,9 +37,13 @@ public class BitZDigest implements ParamsDigest {
             .filter(e -> !e.getKey().equalsIgnoreCase("sign"))
             .map(e -> e.getValue())
             .collect(Collectors.joining())
-            .getBytes();
+            .getBytes(StandardCharsets.UTF_8);
 
-    // TODO: Determine Charceter Encoding
-    return String.valueOf(md5.digest(unsigned));
+    byte[] digest = md5.digest(unsigned);
+    StringBuilder hex = new StringBuilder(digest.length * 2);
+    for (byte b : digest) {
+      hex.append(String.format("%02x", b));
+    }
+    return hex.toString();
   }
 }

--- a/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/service/BTCTurkAccountService.java
+++ b/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/service/BTCTurkAccountService.java
@@ -19,7 +19,6 @@ public class BTCTurkAccountService extends BTCTurkAccountServiceRaw implements A
 
   public BTCTurkAccountService(Exchange exchange) {
     super(exchange);
-    // TODO Auto-generated constructor stub
   }
 
   @Override

--- a/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/service/BTCTurkTradeService.java
+++ b/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/service/BTCTurkTradeService.java
@@ -31,7 +31,6 @@ public class BTCTurkTradeService extends BTCTurkTradeServiceRaw implements Trade
 
   public BTCTurkTradeService(Exchange exchange) {
     super(exchange);
-    // TODO Auto-generated constructor stub
   }
 
   @Override

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectHawkDigest.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectHawkDigest.java
@@ -1,8 +1,8 @@
 package org.knowm.xchange.coindirect.service;
 
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
@@ -82,35 +82,22 @@ public class CoindirectHawkDigest extends BaseParamsDigest {
               + "\"";
 
       return authorization;
-    } catch (MalformedURLException ignored) {
-
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException("Invalid URL: " + restInvocation.getInvocationUrl(), e);
     }
-    return null;
   }
 
   private String generateHash(String key, String data) {
-    Mac sha256_HMAC = null;
-    String result = null;
-
     try {
-      byte[] byteKey = key.getBytes("UTF-8");
+      byte[] byteKey = key.getBytes(StandardCharsets.UTF_8);
       final String HMAC_SHA256 = "HmacSHA256";
-      sha256_HMAC = Mac.getInstance(HMAC_SHA256);
+      Mac sha256_HMAC = Mac.getInstance(HMAC_SHA256);
       SecretKeySpec keySpec = new SecretKeySpec(byteKey, HMAC_SHA256);
       sha256_HMAC.init(keySpec);
-      byte[] mac_data = sha256_HMAC.doFinal(data.getBytes());
+      byte[] mac_data = sha256_HMAC.doFinal(data.getBytes(StandardCharsets.UTF_8));
       return Base64.getEncoder().encodeToString(mac_data);
-    } catch (UnsupportedEncodingException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    } catch (NoSuchAlgorithmException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    } catch (InvalidKeyException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    } finally {
+    } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+      throw new IllegalStateException("Could not generate hash", e);
     }
-    return "";
   }
 }

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
@@ -150,8 +150,7 @@ public class CoinmateAdapters {
       trades.add(trade);
     }
 
-    // TODO correct sort order?
-    return new Trades(trades, Trades.TradeSortType.SortByID);
+    return new Trades(trades, Trades.TradeSortType.SortByTimestamp);
   }
 
   public static Trade adaptTrade(CoinmateTransactionsEntry coinmateEntry) {
@@ -394,14 +393,8 @@ public class CoinmateAdapters {
     List<LimitOrder> ordersList = new ArrayList<>(coinmateOpenOrders.getData().size());
 
     for (CoinmateOpenOrdersEntry entry : coinmateOpenOrders.getData()) {
-
-      Order.OrderType orderType;
-      // TODO
-      if ("BUY".equals(entry.getType())) {
-        orderType = Order.OrderType.BID;
-      } else if ("SELL".equals(entry.getType())) {
-        orderType = Order.OrderType.ASK;
-      } else {
+      Order.OrderType orderType = typeToOrderTypeOrNull(entry.getType());
+      if (orderType == null) {
         throw new CoinmateException("Unknown order type");
       }
 
@@ -522,20 +515,38 @@ public class CoinmateAdapters {
       cumulativeAmount = coinmateOrder.getCumulativeAmount();
     }
 
-    // TODO: we can probably use `orderTradeType` to distinguish between Market and Limit order
-    return new MarketOrder(
-        orderType,
-        originalAmount,
-        null,
-        Long.toString(coinmateOrder.getId()),
-        new Date(coinmateOrder.getTimestamp()),
-        averagePrice,
+    BigDecimal cumulative =
         cumulativeAmount == null
             ? getCumulativeAmount(originalAmount, remainingAmount)
-            : cumulativeAmount,
-        null,
-        orderStatus,
-        null);
+            : cumulativeAmount;
+    String id = Long.toString(coinmateOrder.getId());
+    Date date = new Date(coinmateOrder.getTimestamp());
+
+    if ("MARKET".equalsIgnoreCase(coinmateOrder.getOrderTradeType())) {
+      return new MarketOrder(
+          orderType,
+          originalAmount,
+          null,
+          id,
+          date,
+          averagePrice,
+          cumulative,
+          null,
+          orderStatus,
+          null);
+    } else {
+      return new LimitOrder(
+          orderType,
+          originalAmount,
+          null,
+          id,
+          date,
+          coinmateOrder.getPrice(),
+          averagePrice,
+          cumulative,
+          null,
+          orderStatus);
+    }
   }
 
   public static Ticker adaptTradeStatistics(

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/quant/BasicArbitrageBot.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/quant/BasicArbitrageBot.java
@@ -1,0 +1,41 @@
+package org.knowm.xchange.examples.quant;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.binance.v3.BinanceExchange;
+import org.knowm.xchange.bitstamp.BitstampExchange;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.service.marketdata.MarketDataService;
+
+/**
+ * A very small example showing how XChange can be used as the core of a quantitative
+ * trading system. It retrieves BTC prices from multiple exchanges and prints the
+ * current spread between them. Real trading systems would extend this skeleton with
+ * order execution, persistence and risk management.
+ */
+public class BasicArbitrageBot {
+
+  public static void main(String[] args) throws IOException, InterruptedException {
+    Exchange binance = ExchangeFactory.INSTANCE.createExchange(BinanceExchange.class);
+    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class);
+
+    MarketDataService binanceData = binance.getMarketDataService();
+    MarketDataService bitstampData = bitstamp.getMarketDataService();
+
+    for (int i = 0; i < 5; i++) {
+      Ticker binanceTicker = binanceData.getTicker(CurrencyPair.BTC_USDT);
+      Ticker bitstampTicker = bitstampData.getTicker(CurrencyPair.BTC_USD);
+
+      BigDecimal spread = binanceTicker.getLast().subtract(bitstampTicker.getLast());
+      System.out.printf(
+          "Binance BTC/USDT: %s | Bitstamp BTC/USD: %s | Spread (USDT-USD): %s%n",
+          binanceTicker.getLast(), bitstampTicker.getLast(), spread);
+
+      Thread.sleep(5000L);
+    }
+  }
+}

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Date;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -61,6 +62,7 @@ import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.OrderBookUpdate;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.RateLimitExceededException;
 import org.knowm.xchange.instrument.Instrument;
@@ -975,8 +977,31 @@ public class BinanceStreamingMarketDataService implements StreamingMarketDataSer
           return false;
         } else {
           finalUpdateIdPrev = delta.getLastUpdateId();
-          // FIXME The underlying impl would be more optimal if LimitOrders were created directly.
-          extractOrderBookUpdates(instrument, delta).forEach(update -> book.update(update));
+          Date timestamp = delta.getEventTime();
+          delta.getOrderBook()
+              .bids
+              .forEach(
+                  (price, volume) ->
+                      book.update(
+                          new LimitOrder(
+                              OrderType.BID,
+                              volume,
+                              instrument,
+                              null,
+                              timestamp,
+                              price)));
+          delta.getOrderBook()
+              .asks
+              .forEach(
+                  (price, volume) ->
+                      book.update(
+                          new LimitOrder(
+                              OrderType.ASK,
+                              volume,
+                              instrument,
+                              null,
+                              timestamp,
+                              price)));
         }
         return true;
       }


### PR DESCRIPTION
## Summary
- remove leftover constructor TODOs in BTCTurk account and trade services
- improve BitZ and Coindirect digests with proper exception handling and UTF-8 hashing
- resolve Coinmate adapter TODOs and sort trades by timestamp
- optimize Binance streaming order book updates by constructing LimitOrder objects directly
- add basic multi-exchange arbitrage example demonstrating quantitative trading skeleton

## Testing
- `mvn -q -pl xchange-examples -am test` *(failed: Plugin org.apache.maven.plugins:maven-enforcer-plugin:3.2.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-enforcer-plugin:pom:3.2.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6886ddf5c23c83319787c92690818d86